### PR TITLE
Backport upstream patch to fix compatibility with Sphinx 1.3

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+buildbot (0.8.9-3) UNRELEASED; urgency=medium
+
+  * Backport upstream patch to fix compatibility with Sphinx 1.3
+    (closes: #787175).
+
+ -- Dmitry Shachnev <mitya57@debian.org>  Sat, 15 Aug 2015 21:01:10 +0300
+
 buildbot (0.8.9-2) unstable; urgency=medium
 
   * Update Standards-Version to 3.9.6. No changes required

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -5,3 +5,4 @@ disable-sqlalchemy-version-check.diff
 restart-single-instance.patch
 exit-code.patch
 upgrade-master.patch
+sphinx13-show-urls.patch

--- a/debian/patches/sphinx13-show-urls.patch
+++ b/debian/patches/sphinx13-show-urls.patch
@@ -1,0 +1,20 @@
+Description: change latex_show_urls config option to inline
+Origin: upstream, https://github.com/buildbot/buildbot/commit/4bc42d2178607b1d
+Last-Update: 2015-08-15
+
+--- a/docs/conf.py
++++ b/docs/conf.py
+@@ -214,8 +214,11 @@
+ # If true, show page references after internal links.
+ #latex_show_pagerefs = False
+ 
+-# If true, show URL addresses after external links.
+-latex_show_urls = True
++# Three possible values for this option (see sphinx config manual) are:
++# 1. 'no' – do not display URLs (default)
++# 2. 'footnote' – display URLs in footnotes
++# 3. 'inline' – display URLs inline in parentheses
++latex_show_urls = 'inline'
+ 
+ # Additional stuff for the LaTeX preamble.
+ #latex_preamble = ''


### PR DESCRIPTION
This fixes [bug #787175](https://bugs.debian.org/787175). Note that there is another FTBFS issue (incompatibility with new python-mock, [bug #794300](https://bugs.debian.org/794300)) so this is not enough to make the package build.
